### PR TITLE
Implement `token` callback

### DIFF
--- a/src/connect-client.ts
+++ b/src/connect-client.ts
@@ -8,6 +8,11 @@ export interface ConnectClientOptions {
   endpoint?: string;
 
   /**
+   * The `token` property value.
+   */
+  token?: string | (() => Promise<string>);
+
+  /**
    * The `middlewares` property value.
    */
   middlewares?: Middleware[];
@@ -89,6 +94,11 @@ export class ConnectClient {
   middlewares: Middleware[] = [];
 
   /**
+   * An getter for an access token.
+   */
+  token?: () => Promise<string>;
+
+  /**
    * @param options Constructor options.
    */
   constructor(options: ConnectClientOptions = {}) {
@@ -98,6 +108,14 @@ export class ConnectClient {
 
     if (options.middlewares) {
       this.middlewares = options.middlewares;
+    }
+
+    if (options.token) {
+      if (typeof options.token === 'string') {
+        this.token = () => Promise.resolve(options.token as string);
+      } else {
+        this.token = this.token as () => Promise<string>;
+      }
     }
   }
 
@@ -126,6 +144,12 @@ export class ConnectClient {
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     };
+
+    if (this.token) {
+      const token = this.token();
+      // tslint:disable-next-line:no-string-literal
+      headers['Authorization'] = `Bearer ${token}`;
+    }
 
     // Construct a Request instance from arguments
     const request = new Request(

--- a/test/connect-client.spec.js
+++ b/test/connect-client.spec.js
@@ -62,6 +62,42 @@ describe('ConnectClient', () => {
     });
   });
 
+  describe('token', () => {
+    let client;
+    const vaadinEndpoint = '/connect/FooService/fooMethod';
+
+    beforeEach(() => {
+      client = new ConnectClient();
+      fetchMock.post(vaadinEndpoint, {fooData: 'foo'});
+    });
+
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    describe('without token', () => {
+      it('should not include Authorization header by default', async() => {
+        await client.call('FooService', 'fooMethod');
+        expect(fetchMock.lastOptions().headers)
+          .to.not.have.property('Authorization');
+      });
+    });
+
+    describe('with token', () => {
+      beforeEach(() => {
+        const token = sinon.fake.returns(
+          Promise.resolve('some-base64-here'));
+        client.token = token;
+      });
+
+      it('should ask for token', async() => {
+        await client.call('FooService', 'fooMethod');
+        expect(client.token).to.be.calledOnce;
+        expect(client.token.lastCall).to.be.calledWithExactly();
+      });
+    });
+  });
+
   describe('call method', () => {
     beforeEach(() => fetchMock
       .post('/connect/FooService/fooMethod', {fooData: 'foo'})


### PR DESCRIPTION
- Vaadin Client has a token constructor option
- token is called when user has initiated a call
- when the token callback returns a truthy value, Vaadin Client adds an authorization header to the request